### PR TITLE
EN-817: Mark kube_config/kube_config_raw outputs as sensitive

### DIFF
--- a/modules/azure-kubernetes-cluster/outputs.tf
+++ b/modules/azure-kubernetes-cluster/outputs.tf
@@ -16,11 +16,13 @@ output "private_fqdn" {
 output "kube_config" {
   description = "A kube_config block as defined below."
   value       = azurerm_kubernetes_cluster.cluster.kube_config
+  sensitive   = true
 }
 
 output "kube_config_raw" {
   description = "A kube_config block as defined below."
   value       = azurerm_kubernetes_cluster.cluster.kube_config_raw
+  sensitive   = true
 }
 
 output "client_key" {
@@ -32,16 +34,19 @@ output "client_key" {
 output "client_certificate" {
   description = "The client certificate used to access the Kubernetes cluster."
   value       = azurerm_kubernetes_cluster.cluster.kube_config.0.client_certificate
+  sensitive   = true
 }
 
 output "cluster_ca_certificate" {
   description = "The Kubernetes cluster's root CA certificate."
   value       = azurerm_kubernetes_cluster.cluster.kube_config.0.cluster_ca_certificate
+  sensitive   = true
 }
 
 output "host" {
   description = "The hostname used to access the Kubernetes cluster."
   value       = azurerm_kubernetes_cluster.cluster.kube_config.0.host
+  sensitive   = true
 }
 
 output "identity" {


### PR DESCRIPTION
The azurerm provider marks these as sensitive. During the upgrade to terraform 1.1 it was found that these outputs were lacking the sensitive flag.

```
╷
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 11:
│   11: output "kube_config_raw" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
```