### PR TITLE
EN-975: Update package AKS to provider version >= 3.0

### DIFF
--- a/modules/azure-kubernetes-cluster/README.md
+++ b/modules/azure-kubernetes-cluster/README.md
@@ -1,0 +1,69 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.18.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_api_server_authorized_ip_ranges"></a> [api\_server\_authorized\_ip\_ranges](#input\_api\_server\_authorized\_ip\_ranges) | A list of IP networks in CIDR notation that are permitted to access the API of this cluster. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_dns_prefix"></a> [dns\_prefix](#input\_dns\_prefix) | The DNS prefix associated to the Kubernetes cluster. | `string` | n/a | yes |
+| <a name="input_enable_auto_scaling"></a> [enable\_auto\_scaling](#input\_enable\_auto\_scaling) | Whether or not auto-scaling is enabled. | `bool` | `false` | no |
+| <a name="input_identity_type"></a> [identity\_type](#input\_identity\_type) | The type of identity used for the Kubernetes cluster. | `string` | `"SystemAssigned"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The Kubernetes version deployed in the cluster. | `string` | `null` | no |
+| <a name="input_load_balancer_public_ip_ids"></a> [load\_balancer\_public\_ip\_ids](#input\_load\_balancer\_public\_ip\_ids) | A set of IDs corresponding to the public IP addresses attached to the load balancer. | `set(string)` | `[]` | no |
+| <a name="input_load_balancer_sku"></a> [load\_balancer\_sku](#input\_load\_balancer\_sku) | The SKU of the load balancer that will manage cluster traffic. | `string` | `"standard"` | no |
+| <a name="input_location"></a> [location](#input\_location) | The Azure location where the Kubernetes cluster will be provisioned. | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of log analytics workspace to which AKS will output logs. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the Kubernetes cluster. | `string` | n/a | yes |
+| <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | The network plugin to use for networking. | `string` | `"kubenet"` | no |
+| <a name="input_network_policy"></a> [network\_policy](#input\_network\_policy) | The network policy to be used with Azure CNI (one of `calico` or `azure`). | `string` | `"calico"` | no |
+| <a name="input_node_count"></a> [node\_count](#input\_node\_count) | The number of nodes required to be deployed. | `number` | `1` | no |
+| <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | The name of default node pool. | `string` | `"default"` | no |
+| <a name="input_node_pool_tags"></a> [node\_pool\_tags](#input\_node\_pool\_tags) | A mapping of tags to assign to the nodes. | `map(string)` | `{}` | no |
+| <a name="input_oms_agent_enabled"></a> [oms\_agent\_enabled](#input\_oms\_agent\_enabled) | Whether or not the OMS Agent is enabled. | `bool` | `true` | no |
+| <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | The size of the OS disk (in GB). | `string` | `"30"` | no |
+| <a name="input_private_cluster_enabled"></a> [private\_cluster\_enabled](#input\_private\_cluster\_enabled) | Whether or not the cluster is private. When in private mode, the API is exposed only to private addresses. | `bool` | `true` | no |
+| <a name="input_rbac_aad_admin_group_object_ids"></a> [rbac\_aad\_admin\_group\_object\_ids](#input\_rbac\_aad\_admin\_group\_object\_ids) | value | `list(string)` | `[]` | no |
+| <a name="input_rbac_aad_azure_rbac_enabled"></a> [rbac\_aad\_azure\_rbac\_enabled](#input\_rbac\_aad\_azure\_rbac\_enabled) | value | `bool` | `true` | no |
+| <a name="input_rbac_enabled"></a> [rbac\_enabled](#input\_rbac\_enabled) | Whether or not RBAC is enabled for this cluster. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group in which this Kubernetes cluster will be provisioned. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the cluster. | `map(string)` | `{}` | no |
+| <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | The virtual machine size of each cluster node. | `string` | `"Standard_DS2_v2"` | no |
+| <a name="input_vnet_subnet_id"></a> [vnet\_subnet\_id](#input\_vnet\_subnet\_id) | The ID of the subnet into which the Kubernetes cluster will be deployed. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_client_certificate"></a> [client\_certificate](#output\_client\_certificate) | The client certificate used to access the Kubernetes cluster. |
+| <a name="output_client_key"></a> [client\_key](#output\_client\_key) | The private key corresponding to the provisioned client certificate. |
+| <a name="output_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#output\_cluster\_ca\_certificate) | The Kubernetes cluster's root CA certificate. |
+| <a name="output_fqdn"></a> [fqdn](#output\_fqdn) | The FQDN of the Kubernetes managed cluster. |
+| <a name="output_host"></a> [host](#output\_host) | The hostname used to access the Kubernetes cluster. |
+| <a name="output_id"></a> [id](#output\_id) | The Kubernetes managed cluster ID. |
+| <a name="output_identity"></a> [identity](#output\_identity) | The managed identity used by master components. |
+| <a name="output_kube_config"></a> [kube\_config](#output\_kube\_config) | A kube\_config block as defined below. |
+| <a name="output_kube_config_raw"></a> [kube\_config\_raw](#output\_kube\_config\_raw) | A kube\_config block as defined below. |
+| <a name="output_kubelet_identity"></a> [kubelet\_identity](#output\_kubelet\_identity) | The managed identity assigned to the Kubelets. |
+| <a name="output_private_fqdn"></a> [private\_fqdn](#output\_private\_fqdn) | The FQDN for the Kubernetes cluster when private link has been enabled, which is only resolvable inside the virtual network used by the Kubernetes cluster. |
+<!-- END_TF_DOCS -->

--- a/modules/azure-kubernetes-cluster/main.tf
+++ b/modules/azure-kubernetes-cluster/main.tf
@@ -7,21 +7,24 @@ terraform {
 }
 
 resource "azurerm_kubernetes_cluster" "cluster" {
-  name                    = var.name
-  location                = var.location
-  resource_group_name     = var.resource_group_name
-  node_resource_group     = "${var.resource_group_name}-cluster-resources"
-  tags                    = var.tags
-  kubernetes_version      = var.kubernetes_version
-  private_cluster_enabled = var.private_cluster_enabled
-  dns_prefix              = var.dns_prefix
+  name                              = var.name
+  location                          = var.location
+  resource_group_name               = var.resource_group_name
+  node_resource_group               = "${var.resource_group_name}-cluster-resources"
+  tags                              = var.tags
+  kubernetes_version                = var.kubernetes_version
+  private_cluster_enabled           = var.private_cluster_enabled
+  dns_prefix                        = var.dns_prefix
+  role_based_access_control_enabled = var.rbac_enabled
 
   identity {
     type = var.identity_type
   }
 
-  role_based_access_control {
-    enabled = var.rbac_enabled
+  azure_active_directory_role_based_access_control { # tfsec:ignore:AZU007
+    admin_group_object_ids = var.rbac_aad_admin_group_object_ids
+    azure_rbac_enabled     = var.rbac_aad_azure_rbac_enabled
+    managed                = true
   }
 
   network_profile {
@@ -34,14 +37,8 @@ resource "azurerm_kubernetes_cluster" "cluster" {
     }
   }
 
-  addon_profile {
-    oms_agent {
-      enabled                    = var.oms_agent_enabled
-      log_analytics_workspace_id = var.log_analytics_workspace_id
-    }
-    kube_dashboard {
-      enabled = var.kube_dashboard_enabled
-    }
+  oms_agent { # tfsec:ignore:AZU009
+    log_analytics_workspace_id = var.log_analytics_workspace_id
   }
 
   default_node_pool {

--- a/modules/azure-kubernetes-cluster/vars.tf
+++ b/modules/azure-kubernetes-cluster/vars.tf
@@ -63,7 +63,7 @@ variable "network_policy" {
 variable "load_balancer_sku" {
   description = "The SKU of the load balancer that will manage cluster traffic."
   type        = string
-  default     = "Standard"
+  default     = "standard"
 }
 
 variable "load_balancer_public_ip_ids" {
@@ -82,13 +82,6 @@ variable "oms_agent_enabled" {
   type        = bool
   default     = true
 }
-
-variable "kube_dashboard_enabled" {
-  description = "Whether or not the Kubernetes dashboard is enabled."
-  type        = bool
-  default     = true
-}
-
 variable "node_pool_name" {
   description = "The name of default node pool."
   type        = string
@@ -134,4 +127,16 @@ variable "api_server_authorized_ip_ranges" {
   description = "A list of IP networks in CIDR notation that are permitted to access the API of this cluster."
   type        = list(string)
   default     = ["0.0.0.0/0"]
+}
+
+variable "rbac_aad_admin_group_object_ids" {
+  description = "value"
+  type        = list(string)
+  default     = []
+}
+
+variable "rbac_aad_azure_rbac_enabled" {
+  description = "value"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
I have upgraded the package with minimal changes and expansion since this is critically required for a deliverable. 

I had to add 2 ignore statements for tfsec :
1.  \# tfsec:ignore:AZU007 for rbac enable block
2. \# tfsec:ignore:AZU009 for oms agent block 

Above 2 are currently not supported by tfsec latest version for  azurerm >3.0 providers. 

Here is the terraform plan
<details>
Terraform will perform the following actions:

  # azurerm_kubernetes_cluster.cluster will be created
  + resource "azurerm_kubernetes_cluster" "cluster" {
      + api_server_authorized_ip_ranges     = [
          + "0.0.0.0/0",
        ]
      + dns_prefix                          = "test"
      + fqdn                                = (known after apply)
      + http_application_routing_zone_name  = (known after apply)
      + id                                  = (known after apply)
      + kube_admin_config                   = (sensitive value)
      + kube_admin_config_raw               = (sensitive value)
      + kube_config                         = (sensitive value)
      + kube_config_raw                     = (sensitive value)
      + kubernetes_version                  = (known after apply)
      + location                            = "southeastasia"
      + name                                = "test"
      + node_resource_group                 = "security-log-analytics-cluster-resources"
      + oidc_issuer_url                     = (known after apply)
      + portal_fqdn                         = (known after apply)
      + private_cluster_enabled             = true
      + private_cluster_public_fqdn_enabled = false
      + private_dns_zone_id                 = (known after apply)
      + private_fqdn                        = (known after apply)
      + public_network_access_enabled       = true
      + resource_group_name                 = "security-log-analytics"
      + role_based_access_control_enabled   = true
      + run_command_enabled                 = true
      + sku_tier                            = "Free"

      + auto_scaler_profile {
          + balance_similar_node_groups      = (known after apply)
          + empty_bulk_delete_max            = (known after apply)
          + expander                         = (known after apply)
          + max_graceful_termination_sec     = (known after apply)
          + max_node_provisioning_time       = (known after apply)
          + max_unready_nodes                = (known after apply)
          + max_unready_percentage           = (known after apply)
          + new_pod_scale_up_delay           = (known after apply)
          + scale_down_delay_after_add       = (known after apply)
          + scale_down_delay_after_delete    = (known after apply)
          + scale_down_delay_after_failure   = (known after apply)
          + scale_down_unneeded              = (known after apply)
          + scale_down_unready               = (known after apply)
          + scale_down_utilization_threshold = (known after apply)
          + scan_interval                    = (known after apply)
          + skip_nodes_with_local_storage    = (known after apply)
          + skip_nodes_with_system_pods      = (known after apply)
        }

      + azure_active_directory_role_based_access_control {
          + admin_group_object_ids = []
          + azure_rbac_enabled     = true
          + managed                = true
          + tenant_id              = (known after apply)
        }

      + default_node_pool {
          + enable_auto_scaling  = false
          + kubelet_disk_type    = (known after apply)
          + max_pods             = (known after apply)
          + name                 = "default"
          + node_count           = 1
          + node_labels          = (known after apply)
          + orchestrator_version = (known after apply)
          + os_disk_size_gb      = 30
          + os_disk_type         = "Managed"
          + os_sku               = (known after apply)
          + type                 = "VirtualMachineScaleSets"
          + ultra_ssd_enabled    = false
          + vm_size              = "Standard_DS2_v2"
          + vnet_subnet_id       = "/subscriptions/45c0f42a-e79c-499c-8ef8-19bb21765a06/resourceGroups/security-management/providers/Microsoft.Network/virtualNetworks/vnet-demo-mgmt/subnets/snet-demo-pvt-mgmt"
        }

      + identity {
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
          + type         = "SystemAssigned"
        }

      + kubelet_identity {
          + client_id                 = (known after apply)
          + object_id                 = (known after apply)
          + user_assigned_identity_id = (known after apply)
        }

      + network_profile {
          + dns_service_ip     = (known after apply)
          + docker_bridge_cidr = (known after apply)
          + ip_versions        = (known after apply)
          + load_balancer_sku  = "standard"
          + network_mode       = (known after apply)
          + network_plugin     = "kubenet"
          + network_policy     = "calico"
          + outbound_type      = "loadBalancer"
          + pod_cidr           = (known after apply)
          + service_cidr       = (known after apply)

          + load_balancer_profile {
              + effective_outbound_ips    = (known after apply)
              + idle_timeout_in_minutes   = 30
              + managed_outbound_ip_count = (known after apply)
              + outbound_ip_address_ids   = (known after apply)
              + outbound_ip_prefix_ids    = (known after apply)
              + outbound_ports_allocated  = 0
            }

          + nat_gateway_profile {
              + effective_outbound_ips    = (known after apply)
              + idle_timeout_in_minutes   = (known after apply)
              + managed_outbound_ip_count = (known after apply)
            }
        }

      + oms_agent {
          + log_analytics_workspace_id = "/subscriptions/45c0f42a-e79c-499c-8ef8-19bb21765a06/resourceGroups/security-log-analytics/providers/Microsoft.OperationalInsights/workspaces/quantum-log-analytics-demo"
          + oms_agent_identity         = (known after apply)
        }

      + windows_profile {
          + admin_password = (sensitive value)
          + admin_username = (known after apply)
          + license        = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + client_certificate     = (sensitive value)
  + client_key             = (sensitive value)
  + cluster_ca_certificate = (sensitive value)
  + fqdn                   = (known after apply)
  + host                   = (sensitive value)
  + id                     = (known after apply)
  + identity               = [
      + {
          + identity_ids = null
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
          + type         = "SystemAssigned"
        },
    ]
  + kube_config            = (sensitive value)
  + kube_config_raw        = (sensitive value)
  + kubelet_identity       = (known after apply)
  + private_fqdn           = (known after apply)
</details>